### PR TITLE
refactor: remove duplicate icon definition

### DIFF
--- a/app/[palette]/page.tsx
+++ b/app/[palette]/page.tsx
@@ -6,7 +6,7 @@ import {
 } from "~/colors/presets"
 import { Icon } from "~/icons"
 import { Canvas } from "~/components"
-import { iconLoaders } from "../../src/icons/loaders"
+import { iconLoaders } from "~/icons/loaders"
 
 type PageProps = {
   params: {

--- a/app/[palette]/page.tsx
+++ b/app/[palette]/page.tsx
@@ -36,7 +36,6 @@ const defaultIcons = [
   "lucide-grape",
   "lucide-globe",
   "lucide-magnet",
-  "lucide-magnet",
   "lucide-send",
   "lucide-smile",
   "lucide-test-tube-2",


### PR DESCRIPTION
Removed a duplicate definition of the `lucide-magnet` in the default icons and shortened an import in `app/[palette]/page`.